### PR TITLE
[BUGFIX]: Extraneous gap above Navbar

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -7,7 +7,7 @@ const Header = () => {
   const { title } = siteMetadata();
   const [isExpanded, toggleExpansion] = useState(false);
   return (
-    <header className="bg-gray-200 border-b-2	">
+    <header className="bg-gray-200 border-b-2" style={{marginTop: "-3.5px"}}>
       <div className="flex flex-wrap items-center justify-between max-w-7xl p-4 mx-auto md:p-4">
         <Link to="/">
           <h1 className="flex items-center text-gray-900 no-underline">


### PR DESCRIPTION
The gap was due to the `stars` div. The issue has been resolved by adding a `margin-top: -3.5px` to the `Navbar`.